### PR TITLE
Add configurable table name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@ from arraystore.main import create_array_table, insert_array, retrieve_array
 conn = sqlite3.connect("example.db")
 conn.row_factory = sqlite3.Row
 
-# テーブル作成
-create_array_table(conn)
+# テーブル作成（任意でテーブル名を指定）
+create_array_table(conn, table_name="my_arrays")
 
 # 配列を保存
 my_array = [42, 3.14, None, True, False, "hello", [1, 2], {"a": 1}]
 array_hash = "my_array_hash"
-insert_array(conn, array_hash, my_array)
+insert_array(conn, array_hash, my_array, table_name="my_arrays")
 
 # 配列を復元
-restored = retrieve_array(conn, array_hash)
+restored = retrieve_array(conn, array_hash, table_name="my_arrays")
 print(restored)  # 元の配列と同じ型・値で復元されます
 
 conn.close()
@@ -45,14 +45,14 @@ conn.close()
 
 ## API
 
-- [`create_array_table(conn)`](arraystore/main.py):  
-  配列格納用テーブルを作成します。
+- [`create_array_table(conn, table_name="array_elements")`](arraystore/main.py):
+  配列格納用テーブルを作成します。`table_name` で任意のテーブル名を指定できます。
 
-- [`insert_array(conn, array_hash, array)`](arraystore/main.py):  
-  配列を指定ハッシュ（ID）で保存します。
+- [`insert_array(conn, array_hash, array, table_name="array_elements")`](arraystore/main.py):
+  配列を指定ハッシュ（ID）で保存します。`table_name` で保存先テーブルを指定します。
 
-- [`retrieve_array(conn, array_hash)`](arraystore/main.py):  
-  指定ハッシュの配列を復元します。
+- [`retrieve_array(conn, array_hash, table_name="array_elements")`](arraystore/main.py):
+  指定ハッシュの配列を復元します。`table_name` を揃えることで任意のテーブルから取得できます。
 
 ## テスト
 

--- a/arraystore/main.py
+++ b/arraystore/main.py
@@ -3,10 +3,19 @@
 import sqlite3
 import json
 
-def create_array_table(conn):
-    """Create table and indexes to store array elements."""
-    conn.execute("""
-        CREATE TABLE IF NOT EXISTS array_elements (
+def create_array_table(conn, table_name: str = "array_elements"):
+    """Create table and indexes to store array elements.
+
+    Parameters
+    ----------
+    conn : sqlite3.Connection
+        SQLite connection.
+    table_name : str, optional
+        Name of the table to create. Defaults to ``"array_elements"``.
+    """
+
+    conn.execute(f"""
+        CREATE TABLE IF NOT EXISTS {table_name} (
             array_hash TEXT NOT NULL,
             element_index INTEGER NOT NULL,
             element_value TEXT,
@@ -15,30 +24,33 @@ def create_array_table(conn):
     """)
     # Index on array_hash for faster lookups (optional since PK index exists)
     conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_array_elements_hash ON array_elements(array_hash);"
+        f"CREATE INDEX IF NOT EXISTS idx_{table_name}_hash ON {table_name}(array_hash);"
     )
     conn.commit()
 
-def insert_array(conn, array_hash, array):
+def insert_array(conn, array_hash, array, table_name: str = "array_elements"):
     """Insert array into table using json.dumps to preserve types."""
     cur = conn.cursor()
     for idx, val in enumerate(array):
         # Store JSON literal representation
         value = 'null' if val is None else json.dumps(val)
         cur.execute(
-            "INSERT OR REPLACE INTO array_elements (array_hash, element_index, element_value) VALUES (?, ?, ?)",
+            f"INSERT OR REPLACE INTO {table_name} (array_hash, element_index, element_value) VALUES (?, ?, ?)",
             (array_hash, idx, value)
         )
     conn.commit()
 
-def retrieve_array(conn, array_hash):
+def retrieve_array(conn, array_hash, table_name: str = "array_elements"):
     """Retrieve array as Python list with preserved types."""
     cur = conn.cursor()
-    cur.execute("""
+    cur.execute(
+        f"""
         SELECT '[' || GROUP_CONCAT(element_value, ',') || ']' AS json_array
-        FROM array_elements
+        FROM {table_name}
         WHERE array_hash = ?
         GROUP BY array_hash;
-    """, (array_hash,))
+    """,
+        (array_hash,),
+    )
     row = cur.fetchone()
     return json.loads(row['json_array']) if row else []

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -80,6 +80,23 @@ def test_method1_object_array():
     conn.close()
 
 
+def test_custom_table_name():
+    """Test using a custom table name for storage and retrieval."""
+    custom_table = "custom_elements"
+    test_array = [1, 2, 3]
+    array_hash = "custom_table_test"
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    create_array_table(conn, table_name=custom_table)
+    insert_array(conn, array_hash, test_array, table_name=custom_table)
+    result = retrieve_array(conn, array_hash, table_name=custom_table)
+
+    assert result == test_array
+    conn.close()
+
+
 if __name__ == "__main__":
     test_method1_storage()
     test_method1_nested_array()


### PR DESCRIPTION
## Summary
- let callers choose a table name in `create_array_table`, `insert_array`, and `retrieve_array`
- document the optional parameter in README examples and API section
- test storing arrays using a custom table name

## Testing
- `PYTHONPATH=$(pwd) pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a01f00ffc832ba331d0f65243be9b