### PR TITLE
Change default table name

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ conn.close()
 
 ## API
 
-- [`create_array_table(conn, table_name="array_elements")`](arraystore/main.py):
+- [`create_array_table(conn, table_name="arraystore")`](arraystore/main.py):
   配列格納用テーブルを作成します。`table_name` で任意のテーブル名を指定できます。
 
-- [`insert_array(conn, array_hash, array, table_name="array_elements")`](arraystore/main.py):
+- [`insert_array(conn, array_hash, array, table_name="arraystore")`](arraystore/main.py):
   配列を指定ハッシュ（ID）で保存します。`table_name` で保存先テーブルを指定します。
 
-- [`retrieve_array(conn, array_hash, table_name="array_elements")`](arraystore/main.py):
+- [`retrieve_array(conn, array_hash, table_name="arraystore")`](arraystore/main.py):
   指定ハッシュの配列を復元します。`table_name` を揃えることで任意のテーブルから取得できます。
 
 ## テスト

--- a/arraystore/main.py
+++ b/arraystore/main.py
@@ -3,7 +3,7 @@
 import sqlite3
 import json
 
-def create_array_table(conn, table_name: str = "array_elements"):
+def create_array_table(conn, table_name: str = "arraystore"):
     """Create table and indexes to store array elements.
 
     Parameters
@@ -11,7 +11,7 @@ def create_array_table(conn, table_name: str = "array_elements"):
     conn : sqlite3.Connection
         SQLite connection.
     table_name : str, optional
-        Name of the table to create. Defaults to ``"array_elements"``.
+        Name of the table to create. Defaults to ``"arraystore"``.
     """
 
     conn.execute(f"""
@@ -28,7 +28,7 @@ def create_array_table(conn, table_name: str = "array_elements"):
     )
     conn.commit()
 
-def insert_array(conn, array_hash, array, table_name: str = "array_elements"):
+def insert_array(conn, array_hash, array, table_name: str = "arraystore"):
     """Insert array into table using json.dumps to preserve types."""
     cur = conn.cursor()
     for idx, val in enumerate(array):
@@ -40,7 +40,7 @@ def insert_array(conn, array_hash, array, table_name: str = "array_elements"):
         )
     conn.commit()
 
-def retrieve_array(conn, array_hash, table_name: str = "array_elements"):
+def retrieve_array(conn, array_hash, table_name: str = "arraystore"):
     """Retrieve array as Python list with preserved types."""
     cur = conn.cursor()
     cur.execute(


### PR DESCRIPTION
## Summary
- change default table name from `array_elements` to `arraystore`
- document new default table in README

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a042e5ca0832bb8c1a0b61ef3d9a8