### PR TITLE
Add objectstore module for storing dictionaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # arraystore
 
-Pythonリスト（配列）を**型を保ったままSQLiteデータベースに保存・復元**するためのシンプルなライブラリです。  
+Pythonリスト（配列）を**型を保ったままSQLiteデータベースに保存・復元**するためのシンプルなライブラリです。また、同じ仕組みでPython辞書を扱う``objectstore``モジュールも提供します。
 各要素をJSONリテラルとして保存することで、数値・真偽値・null・文字列・ネスト配列・辞書など、Pythonの型を損なわずに格納できます。
 
 ## 特徴
@@ -43,6 +43,27 @@ print(restored)  # 元の配列と同じ型・値で復元されます
 conn.close()
 ```
 
+### オブジェクトの保存
+
+```python
+import sqlite3
+from objectstore.main import create_object_table, insert_object, retrieve_object
+
+conn = sqlite3.connect("example.db")
+conn.row_factory = sqlite3.Row
+
+create_object_table(conn, table_name="my_objects")
+
+my_obj = {"name": "Alice", "age": 30, "flags": [True, False]}
+obj_hash = "my_obj_hash"
+insert_object(conn, obj_hash, my_obj, table_name="my_objects")
+
+restored = retrieve_object(conn, obj_hash, table_name="my_objects")
+print(restored)  # 元の辞書と同じ型・値で復元されます
+
+conn.close()
+```
+
 ## API
 
 - [`create_array_table(conn, table_name="arraystore")`](arraystore/main.py):
@@ -53,6 +74,15 @@ conn.close()
 
 - [`retrieve_array(conn, array_hash, table_name="arraystore")`](arraystore/main.py):
   指定ハッシュの配列を復元します。`table_name` を揃えることで任意のテーブルから取得できます。
+
+- [`create_object_table(conn, table_name="objectstore")`](objectstore/main.py):
+  辞書格納用テーブルを作成します。`table_name` で任意のテーブル名を指定できます。
+
+- [`insert_object(conn, object_hash, obj, table_name="objectstore")`](objectstore/main.py):
+  辞書を指定ハッシュで保存します。`table_name` で保存先テーブルを指定します。
+
+- [`retrieve_object(conn, object_hash, table_name="objectstore")`](objectstore/main.py):
+  指定ハッシュの辞書を復元します。`table_name` を揃えることで任意のテーブルから取得できます。
 
 ## テスト
 

--- a/objectstore/__init__.py
+++ b/objectstore/__init__.py
@@ -1,0 +1,1 @@
+# This file makes objectstore a Python package.

--- a/objectstore/main.py
+++ b/objectstore/main.py
@@ -1,0 +1,56 @@
+# main.py for objectstore
+
+import sqlite3
+import json
+
+
+def create_object_table(conn: sqlite3.Connection, table_name: str = "objectstore"):
+    """Create table and indexes to store object properties.
+
+    Parameters
+    ----------
+    conn : sqlite3.Connection
+        SQLite connection.
+    table_name : str, optional
+        Name of the table to create. Defaults to ``"objectstore"``.
+    """
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {table_name} (
+            object_hash TEXT NOT NULL,
+            property_name TEXT NOT NULL,
+            property_json TEXT,
+            PRIMARY KEY (object_hash, property_name)
+        );
+        """
+    )
+    conn.execute(
+        f"CREATE INDEX IF NOT EXISTS idx_{table_name}_hash ON {table_name}(object_hash);"
+    )
+    conn.commit()
+
+
+def insert_object(conn: sqlite3.Connection, object_hash, obj: dict, table_name: str = "objectstore"):
+    """Insert a Python dict into the table preserving JSON types."""
+    cur = conn.cursor()
+    for key, val in obj.items():
+        value = 'null' if val is None else json.dumps(val)
+        cur.execute(
+            f"INSERT OR REPLACE INTO {table_name} (object_hash, property_name, property_json) VALUES (?, ?, ?)",
+            (object_hash, key, value),
+        )
+    conn.commit()
+
+
+def retrieve_object(conn: sqlite3.Connection, object_hash, table_name: str = "objectstore"):
+    """Retrieve a Python dict previously stored with insert_object."""
+    cur = conn.cursor()
+    cur.execute(
+        f"SELECT property_name, property_json FROM {table_name} WHERE object_hash = ?",
+        (object_hash,),
+    )
+    rows = cur.fetchall()
+    result = {}
+    for row in rows:
+        result[row[0]] = json.loads(row[1]) if row[1] is not None else None
+    return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 description = "A library to store and retrieve Python lists/arrays in SQLite using JSON."
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"
-packages = [{include = "arraystore"}]
+packages = [
+    {include = "arraystore"},
+    {include = "objectstore"}
+]
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/tests/test_objectstore.py
+++ b/tests/test_objectstore.py
@@ -1,0 +1,33 @@
+import sqlite3
+import json
+from objectstore.main import create_object_table, insert_object, retrieve_object
+
+
+def test_object_storage():
+    data = {"a": 1, "b": True, "c": None, "d": [1, 2], "e": {"x": False}}
+    obj_hash = "objhash"
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    create_object_table(conn)
+    insert_object(conn, obj_hash, data)
+    result = retrieve_object(conn, obj_hash)
+
+    assert result == data
+    assert json.dumps(result, sort_keys=True) == json.dumps(data, sort_keys=True)
+    conn.close()
+
+
+def test_custom_table_name_object():
+    custom_table = "custom_objects"
+    data = {"key": "value"}
+    obj_hash = "custom_obj"
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    create_object_table(conn, table_name=custom_table)
+    insert_object(conn, obj_hash, data, table_name=custom_table)
+    result = retrieve_object(conn, obj_hash, table_name=custom_table)
+
+    assert result == data
+    conn.close()


### PR DESCRIPTION
## Summary
- implement `objectstore` module to store dictionaries in SQLite
- update packaging to include new module
- document usage and API for object storage
- add tests for `objectstore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a1747a884832ba84f67d414c1eeeb