### PR TITLE
Rename array_hash column

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ create_array_table(conn, table_name="my_arrays")
 
 # 配列を保存
 my_array = [42, 3.14, None, True, False, "hello", [1, 2], {"a": 1}]
-array_hash = "my_array_hash"
-insert_array(conn, array_hash, my_array, table_name="my_arrays")
+canonical_json_sha1 = "my_array_hash"
+insert_array(conn, canonical_json_sha1, my_array, table_name="my_arrays")
 
 # 配列を復元
-restored = retrieve_array(conn, array_hash, table_name="my_arrays")
+restored = retrieve_array(conn, canonical_json_sha1, table_name="my_arrays")
 print(restored)  # 元の配列と同じ型・値で復元されます
 
 conn.close()
@@ -48,10 +48,10 @@ conn.close()
 - [`create_array_table(conn, table_name="arraystore")`](arraystore/main.py):
   配列格納用テーブルを作成します。`table_name` で任意のテーブル名を指定できます。
 
-- [`insert_array(conn, array_hash, array, table_name="arraystore")`](arraystore/main.py):
+- [`insert_array(conn, canonical_json_sha1, array, table_name="arraystore")`](arraystore/main.py):
   配列を指定ハッシュ（ID）で保存します。`table_name` で保存先テーブルを指定します。
 
-- [`retrieve_array(conn, array_hash, table_name="arraystore")`](arraystore/main.py):
+- [`retrieve_array(conn, canonical_json_sha1, table_name="arraystore")`](arraystore/main.py):
   指定ハッシュの配列を復元します。`table_name` を揃えることで任意のテーブルから取得できます。
 
 ## テスト

--- a/arraystore/main.py
+++ b/arraystore/main.py
@@ -16,41 +16,41 @@ def create_array_table(conn, table_name: str = "arraystore"):
 
     conn.execute(f"""
         CREATE TABLE IF NOT EXISTS {table_name} (
-            array_hash TEXT NOT NULL,
+            canonical_json_sha1 TEXT NOT NULL,
             element_index INTEGER NOT NULL,
             element_json TEXT,
-            PRIMARY KEY (array_hash, element_index)
+            PRIMARY KEY (canonical_json_sha1, element_index)
         );
     """)
-    # Index on array_hash for faster lookups (optional since PK index exists)
+    # Index on canonical_json_sha1 for faster lookups (optional since PK index exists)
     conn.execute(
-        f"CREATE INDEX IF NOT EXISTS idx_{table_name}_hash ON {table_name}(array_hash);"
+        f"CREATE INDEX IF NOT EXISTS idx_{table_name}_hash ON {table_name}(canonical_json_sha1);"
     )
     conn.commit()
 
-def insert_array(conn, array_hash, array, table_name: str = "arraystore"):
+def insert_array(conn, canonical_json_sha1, array, table_name: str = "arraystore"):
     """Insert array into table using json.dumps to preserve types."""
     cur = conn.cursor()
     for idx, val in enumerate(array):
         # Store JSON literal representation
         value = 'null' if val is None else json.dumps(val)
         cur.execute(
-            f"INSERT OR REPLACE INTO {table_name} (array_hash, element_index, element_json) VALUES (?, ?, ?)",
-            (array_hash, idx, value)
+            f"INSERT OR REPLACE INTO {table_name} (canonical_json_sha1, element_index, element_json) VALUES (?, ?, ?)",
+            (canonical_json_sha1, idx, value)
         )
     conn.commit()
 
-def retrieve_array(conn, array_hash, table_name: str = "arraystore"):
+def retrieve_array(conn, canonical_json_sha1, table_name: str = "arraystore"):
     """Retrieve array as Python list with preserved types."""
     cur = conn.cursor()
     cur.execute(
         f"""
         SELECT '[' || GROUP_CONCAT(element_json, ',') || ']' AS json_array
         FROM {table_name}
-        WHERE array_hash = ?
-        GROUP BY array_hash;
+        WHERE canonical_json_sha1 = ?
+        GROUP BY canonical_json_sha1;
     """,
-        (array_hash,),
+        (canonical_json_sha1,),
     )
     row = cur.fetchone()
     return json.loads(row['json_array']) if row else []

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,13 +8,13 @@ from arraystore.main import create_array_table, insert_array, retrieve_array
 def test_method1_storage():
     """Test storing and retrieving array via Method 1."""
     test_array = [42, 3.14, None, True, False, "hello", "true", "false", "null", "", 0, -0, 1, -1, "0", "1"]
-    array_hash = "testhash"
+    canonical_json_sha1 = "testhash"
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
     create_array_table(conn)
-    insert_array(conn, array_hash, test_array)
-    result = retrieve_array(conn, array_hash)
+    insert_array(conn, canonical_json_sha1, test_array)
+    result = retrieve_array(conn, canonical_json_sha1)
 
     assert result == test_array, (
         f"Restored array does not match original.\n"
@@ -32,13 +32,13 @@ def test_method1_storage():
 def test_method1_nested_array():
     """Test storing and retrieving nested arrays via Method 1."""
     nested_array = [[1, 2], ["a", True], [], [None, [3.14]]]
-    array_hash = "nested_test"
+    canonical_json_sha1 = "nested_test"
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
     create_array_table(conn)
-    insert_array(conn, array_hash, nested_array)
-    result = retrieve_array(conn, array_hash)
+    insert_array(conn, canonical_json_sha1, nested_array)
+    result = retrieve_array(conn, canonical_json_sha1)
 
     assert result == nested_array, (
         f"Restored nested array does not match original.\n"
@@ -59,13 +59,13 @@ def test_method1_object_array():
         {"a": 1, "b": [2, False]},
         {"nested": {"x": True, "y": None}}
     ]
-    array_hash = "object_test"
+    canonical_json_sha1 = "object_test"
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
     create_array_table(conn)
-    insert_array(conn, array_hash, object_array)
-    result = retrieve_array(conn, array_hash)
+    insert_array(conn, canonical_json_sha1, object_array)
+    result = retrieve_array(conn, canonical_json_sha1)
 
     assert result == object_array, (
         f"Restored object array does not match original.\n"
@@ -84,14 +84,14 @@ def test_custom_table_name():
     """Test using a custom table name for storage and retrieval."""
     custom_table = "custom_elements"
     test_array = [1, 2, 3]
-    array_hash = "custom_table_test"
+    canonical_json_sha1 = "custom_table_test"
 
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
     create_array_table(conn, table_name=custom_table)
-    insert_array(conn, array_hash, test_array, table_name=custom_table)
-    result = retrieve_array(conn, array_hash, table_name=custom_table)
+    insert_array(conn, canonical_json_sha1, test_array, table_name=custom_table)
+    result = retrieve_array(conn, canonical_json_sha1, table_name=custom_table)
 
     assert result == test_array
     conn.close()


### PR DESCRIPTION
## Summary
- rename database column `array_hash` to `canonical_json_sha1`
- update README examples and API docs
- update tests for new column name

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a17a9456c832bad4365d5172101be