### PR TITLE
Rename object_hash column to canonical_json_sha1

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ conn.row_factory = sqlite3.Row
 create_object_table(conn, table_name="my_objects")
 
 my_obj = {"name": "Alice", "age": 30, "flags": [True, False]}
-obj_hash = "my_obj_hash"
-insert_object(conn, obj_hash, my_obj, table_name="my_objects")
+canonical_json_sha1 = "my_obj_hash"
+insert_object(conn, canonical_json_sha1, my_obj, table_name="my_objects")
 
-restored = retrieve_object(conn, obj_hash, table_name="my_objects")
+restored = retrieve_object(conn, canonical_json_sha1, table_name="my_objects")
 print(restored)  # 元の辞書と同じ型・値で復元されます
 
 conn.close()
@@ -78,10 +78,10 @@ conn.close()
 - [`create_object_table(conn, table_name="objectstore")`](objectstore/main.py):
   辞書格納用テーブルを作成します。`table_name` で任意のテーブル名を指定できます。
 
-- [`insert_object(conn, object_hash, obj, table_name="objectstore")`](objectstore/main.py):
+- [`insert_object(conn, canonical_json_sha1, obj, table_name="objectstore")`](objectstore/main.py):
   辞書を指定ハッシュで保存します。`table_name` で保存先テーブルを指定します。
 
-- [`retrieve_object(conn, object_hash, table_name="objectstore")`](objectstore/main.py):
+- [`retrieve_object(conn, canonical_json_sha1, table_name="objectstore")`](objectstore/main.py):
   指定ハッシュの辞書を復元します。`table_name` を揃えることで任意のテーブルから取得できます。
 
 ## テスト

--- a/objectstore/main.py
+++ b/objectstore/main.py
@@ -17,37 +17,37 @@ def create_object_table(conn: sqlite3.Connection, table_name: str = "objectstore
     conn.execute(
         f"""
         CREATE TABLE IF NOT EXISTS {table_name} (
-            object_hash TEXT NOT NULL,
+            canonical_json_sha1 TEXT NOT NULL,
             property_name TEXT NOT NULL,
             property_json TEXT,
-            PRIMARY KEY (object_hash, property_name)
+            PRIMARY KEY (canonical_json_sha1, property_name)
         );
         """
     )
     conn.execute(
-        f"CREATE INDEX IF NOT EXISTS idx_{table_name}_hash ON {table_name}(object_hash);"
+        f"CREATE INDEX IF NOT EXISTS idx_{table_name}_hash ON {table_name}(canonical_json_sha1);"
     )
     conn.commit()
 
 
-def insert_object(conn: sqlite3.Connection, object_hash, obj: dict, table_name: str = "objectstore"):
+def insert_object(conn: sqlite3.Connection, canonical_json_sha1, obj: dict, table_name: str = "objectstore"):
     """Insert a Python dict into the table preserving JSON types."""
     cur = conn.cursor()
     for key, val in obj.items():
         value = 'null' if val is None else json.dumps(val)
         cur.execute(
-            f"INSERT OR REPLACE INTO {table_name} (object_hash, property_name, property_json) VALUES (?, ?, ?)",
-            (object_hash, key, value),
+            f"INSERT OR REPLACE INTO {table_name} (canonical_json_sha1, property_name, property_json) VALUES (?, ?, ?)",
+            (canonical_json_sha1, key, value),
         )
     conn.commit()
 
 
-def retrieve_object(conn: sqlite3.Connection, object_hash, table_name: str = "objectstore"):
+def retrieve_object(conn: sqlite3.Connection, canonical_json_sha1, table_name: str = "objectstore"):
     """Retrieve a Python dict previously stored with insert_object."""
     cur = conn.cursor()
     cur.execute(
-        f"SELECT property_name, property_json FROM {table_name} WHERE object_hash = ?",
-        (object_hash,),
+        f"SELECT property_name, property_json FROM {table_name} WHERE canonical_json_sha1 = ?",
+        (canonical_json_sha1,),
     )
     rows = cur.fetchall()
     result = {}

--- a/tests/test_objectstore.py
+++ b/tests/test_objectstore.py
@@ -5,13 +5,13 @@ from objectstore.main import create_object_table, insert_object, retrieve_object
 
 def test_object_storage():
     data = {"a": 1, "b": True, "c": None, "d": [1, 2], "e": {"x": False}}
-    obj_hash = "objhash"
+    canonical_json_sha1 = "objhash"
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
     create_object_table(conn)
-    insert_object(conn, obj_hash, data)
-    result = retrieve_object(conn, obj_hash)
+    insert_object(conn, canonical_json_sha1, data)
+    result = retrieve_object(conn, canonical_json_sha1)
 
     assert result == data
     assert json.dumps(result, sort_keys=True) == json.dumps(data, sort_keys=True)
@@ -21,13 +21,13 @@ def test_object_storage():
 def test_custom_table_name_object():
     custom_table = "custom_objects"
     data = {"key": "value"}
-    obj_hash = "custom_obj"
+    canonical_json_sha1 = "custom_obj"
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
     create_object_table(conn, table_name=custom_table)
-    insert_object(conn, obj_hash, data, table_name=custom_table)
-    result = retrieve_object(conn, obj_hash, table_name=custom_table)
+    insert_object(conn, canonical_json_sha1, data, table_name=custom_table)
+    result = retrieve_object(conn, canonical_json_sha1, table_name=custom_table)
 
     assert result == data
     conn.close()


### PR DESCRIPTION
## Summary
- rename column `object_hash` to `canonical_json_sha1`
- update docs and tests

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a18e80134832bb655d1ced952ef75