### PR TITLE
Rename main test and extend object store tests

### DIFF
--- a/tests/test_arraystore.py
+++ b/tests/test_arraystore.py
@@ -1,7 +1,11 @@
-# test_main.py
+# test_arraystore.py
 
+import os
+import sys
 import sqlite3
 import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from arraystore.main import create_array_table, insert_array, retrieve_array
 
 

--- a/tests/test_objectstore.py
+++ b/tests/test_objectstore.py
@@ -1,5 +1,9 @@
+import os
+import sys
 import sqlite3
 import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from objectstore.main import create_object_table, insert_object, retrieve_object
 
 
@@ -30,4 +34,38 @@ def test_custom_table_name_object():
     result = retrieve_object(conn, obj_hash, table_name=custom_table)
 
     assert result == data
+    conn.close()
+
+
+def test_object_storage_various_types():
+    values = [
+        42,
+        3.14,
+        None,
+        True,
+        False,
+        "hello",
+        "true",
+        "false",
+        "null",
+        "",
+        0,
+        -0,
+        1,
+        -1,
+        "0",
+        "1",
+    ]
+    data = {f"val_{i}": v for i, v in enumerate(values)}
+    obj_hash = "various_types"
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    create_object_table(conn)
+    insert_object(conn, obj_hash, data)
+    result = retrieve_object(conn, obj_hash)
+
+    assert result == data
+    for key, val in data.items():
+        assert type(result[key]) is type(val)
     conn.close()


### PR DESCRIPTION
## Summary
- rename `tests/test_main.py` to `tests/test_arraystore.py`
- adjust imports in tests so they can run without installing the package
- add a comprehensive test in `tests/test_objectstore.py` that verifies
  storage and retrieval of various types

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a197bf8f4832b8de7b258190cf342