### PR TITLE
Add tests for emoji and control characters

### DIFF
--- a/tests/test_canonicaljson.py
+++ b/tests/test_canonicaljson.py
@@ -32,3 +32,22 @@ def test_canonical_complex_structure():
     }
     expected = jcs.canonicalize(obj).decode("utf-8")
     assert canonical_json(obj) == expected
+
+
+def test_unicode_in_keys_and_values():
+    obj = {
+        "😀": "🍣 sushi",
+        "text": "こんにちは世界",
+        "emoji_key\U0001F600": "value",
+    }
+    expected = jcs.canonicalize(obj).decode("utf-8")
+    assert canonical_json(obj) == expected
+
+
+def test_control_chars_in_strings():
+    obj = {
+        "line\nbreak": "val\tcontrol",
+        "ctrl\u0001key": "\u0002value",
+    }
+    expected = jcs.canonicalize(obj).decode("utf-8")
+    assert canonical_json(obj) == expected


### PR DESCRIPTION
## Summary
- cover unicode emoji cases in canonical JSON tests
- add coverage for control characters in JSON strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a2698fac0832b96fa23583489ec86