### PR TITLE
Add SHA1 columns to array and object stores

### DIFF
--- a/docs/table_structure.md
+++ b/docs/table_structure.md
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS {table_name} (
     canonical_json_sha1 TEXT NOT NULL,
     element_index       INTEGER NOT NULL,
     element_json        TEXT,
+    element_json_sha1   TEXT,
     PRIMARY KEY (canonical_json_sha1, element_index)
 );
 CREATE INDEX IF NOT EXISTS idx_{table_name}_hash
@@ -20,6 +21,7 @@ CREATE INDEX IF NOT EXISTS idx_{table_name}_hash
 - `canonical_json_sha1`: 配列全体をカノニカル JSON 形式でハッシュ化した値。配列 ID として機能します。
 - `element_index`: 配列要素のインデックス (0 から開始)。
 - `element_json`: 各要素を JSON リテラルとして保存した値。
+- `element_json_sha1`: 各要素の JSON を SHA1 ハッシュ化した値。
 
 主キーは `(canonical_json_sha1, element_index)` であり、同一配列内の各要素を一意に識別します。また、`canonical_json_sha1` での検索を高速化するために専用インデックスが作成されます。
 
@@ -32,6 +34,7 @@ CREATE TABLE IF NOT EXISTS {table_name} (
     canonical_json_sha1 TEXT NOT NULL,
     property_name       TEXT NOT NULL,
     property_json       TEXT,
+    property_json_sha1  TEXT,
     PRIMARY KEY (canonical_json_sha1, property_name)
 );
 CREATE INDEX IF NOT EXISTS idx_{table_name}_hash
@@ -41,6 +44,7 @@ CREATE INDEX IF NOT EXISTS idx_{table_name}_hash
 - `canonical_json_sha1`: 辞書全体のカノニカル JSON ハッシュ。
 - `property_name`: 辞書のキー名。
 - `property_json`: 各値を JSON リテラルとして保存したもの。
+- `property_json_sha1`: 各値の JSON を SHA1 ハッシュ化したもの。
 
 主キーは `(canonical_json_sha1, property_name)` です。こちらもハッシュ値にインデックスを張ることで、同一オブジェクトを高速に取得できます。
 

--- a/sqlite_store/arraystore/main.py
+++ b/sqlite_store/arraystore/main.py
@@ -36,6 +36,7 @@ def create_array_table(conn: sqlite3.Connection, table_name: str = "arraystore")
             canonical_json_sha1 TEXT NOT NULL,
             element_index INTEGER NOT NULL,
             element_json TEXT,
+            element_json_sha1 TEXT,
             PRIMARY KEY (canonical_json_sha1, element_index)
         );
     """)
@@ -56,9 +57,10 @@ def insert_array(
     for idx, val in enumerate(array):
         # Store canonical JSON literal representation of each element
         value = canonical_json(val)
+        value_sha1 = hashlib.sha1(value.encode("utf-8")).hexdigest()
         cur.execute(
-            f"INSERT OR REPLACE INTO {table_name} (canonical_json_sha1, element_index, element_json) VALUES (?, ?, ?)",
-            (canonical_json_sha1, idx, value)
+            f"INSERT OR REPLACE INTO {table_name} (canonical_json_sha1, element_index, element_json, element_json_sha1) VALUES (?, ?, ?, ?)",
+            (canonical_json_sha1, idx, value, value_sha1)
         )
     conn.commit()
 

--- a/sqlite_store/objectstore/main.py
+++ b/sqlite_store/objectstore/main.py
@@ -36,6 +36,7 @@ def create_object_table(conn: sqlite3.Connection, table_name: str = "objectstore
             canonical_json_sha1 TEXT NOT NULL,
             property_name TEXT NOT NULL,
             property_json TEXT,
+            property_json_sha1 TEXT,
             PRIMARY KEY (canonical_json_sha1, property_name)
         );
         """
@@ -56,9 +57,10 @@ def insert_object(
     cur = conn.cursor()
     for key, val in obj.items():
         value = canonical_json(val)
+        value_sha1 = hashlib.sha1(value.encode("utf-8")).hexdigest()
         cur.execute(
-            f"INSERT OR REPLACE INTO {table_name} (canonical_json_sha1, property_name, property_json) VALUES (?, ?, ?)",
-            (canonical_json_sha1, key, value),
+            f"INSERT OR REPLACE INTO {table_name} (canonical_json_sha1, property_name, property_json, property_json_sha1) VALUES (?, ?, ?, ?)",
+            (canonical_json_sha1, key, value, value_sha1),
         )
     conn.commit()
 

--- a/tests/test_arraystore.py
+++ b/tests/test_arraystore.py
@@ -137,13 +137,16 @@ def test_element_json_canonical():
 
     cur = conn.cursor()
     cur.execute(
-        "SELECT element_index, element_json FROM arraystore WHERE canonical_json_sha1 = ? ORDER BY element_index",
+        "SELECT element_index, element_json, element_json_sha1 FROM arraystore WHERE canonical_json_sha1 = ? ORDER BY element_index",
         (cid,),
     )
     rows = cur.fetchall()
 
-    for idx, json_val in rows:
-        assert json_val == canonical_json(data[idx])
+    for idx, json_val, sha1_val in rows:
+        canon = canonical_json(data[idx])
+        expected_sha1 = hashlib.sha1(canon.encode("utf-8")).hexdigest()
+        assert json_val == canon
+        assert sha1_val == expected_sha1
     conn.close()
 
 

--- a/tests/test_objectstore.py
+++ b/tests/test_objectstore.py
@@ -111,7 +111,7 @@ def test_property_json_is_canonical():
 
     cur = conn.cursor()
     cur.execute(
-        "SELECT property_name, property_json FROM objectstore WHERE canonical_json_sha1 = ?",
+        "SELECT property_name, property_json, property_json_sha1 FROM objectstore WHERE canonical_json_sha1 = ?",
         (hash_id,),
     )
     rows = cur.fetchall()
@@ -119,5 +119,9 @@ def test_property_json_is_canonical():
     for row in rows:
         name = row[0]
         stored = row[1]
-        assert stored == canonical_json(obj[name])
+        sha1_val = row[2]
+        canonical = canonical_json(obj[name])
+        expected_sha1 = hashlib.sha1(canonical.encode("utf-8")).hexdigest()
+        assert stored == canonical
+        assert sha1_val == expected_sha1
     conn.close()


### PR DESCRIPTION
## Summary
- store SHA1 of each property in `objectstore`
- store SHA1 of each element in `arraystore`
- document the new `*_json_sha1` columns
- verify SHA1 values in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a48bb7c7c832b90aa049dfdf457b2