### PR TITLE
Add bulk insertion for objectstore

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ canonical_str = canonical_json({"b": 1, "a": True})
 - [`insert_object(conn, canonical_json_sha1, obj, table_name="objectstore")`](sqlite_store/objectstore/main.py):
   辞書を指定ハッシュで保存します。`table_name` で保存先テーブルを指定します。
 
+- [`insert_object_auto_hash(conn, obj, table_name="objectstore")`](sqlite_store/objectstore/main.py):
+  辞書保存時にSHA1ハッシュを自動計算して利用します。計算したハッシュ値を返します。
+- [`insert_objects_auto_hash(conn, objs, table_name="objectstore")`](sqlite_store/objectstore/main.py):
+  複数の辞書を同時に保存する際にSHA1を自動計算します。ハッシュ値のリストを返します。
+
 - [`retrieve_object(conn, canonical_json_sha1, table_name="objectstore")`](sqlite_store/objectstore/main.py):
   指定ハッシュの辞書を復元します。`table_name` を揃えることで任意のテーブルから取得できます。
 - [`create_json_table(conn, table_name="jsonstore")`](sqlite_store/jsonstore/main.py): JSON全体を保存するテーブルを作成します.

--- a/tests/test_objectstore.py
+++ b/tests/test_objectstore.py
@@ -9,6 +9,7 @@ from sqlite_store.objectstore.main import (
     create_object_table,
     insert_object,
     insert_object_auto_hash,
+    insert_objects_auto_hash,
     retrieve_object,
 )
 from sqlite_store import canonical_json
@@ -120,4 +121,26 @@ def test_property_json_is_canonical():
         name = row[0]
         stored = row[1]
         assert stored == canonical_json(obj[name])
+    conn.close()
+
+
+def test_insert_objects_auto_hash():
+    objs = [
+        {"a": 1, "b": True},
+        {"x": [1, 2], "y": None},
+    ]
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    create_object_table(conn)
+    hashes = insert_objects_auto_hash(conn, objs)
+
+    expected = [
+        hashlib.sha1(canonical_json(o).encode("utf-8")).hexdigest() for o in objs
+    ]
+
+    assert hashes == expected
+    for h, original in zip(hashes, objs):
+        restored = retrieve_object(conn, h)
+        assert restored == original
     conn.close()


### PR DESCRIPTION
## Summary
- support inserting multiple objects with `insert_objects_auto_hash`
- document new API
- test bulk insertion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a49747148832b820716ed689f3dbf