### PR TITLE
Expose submodule API via package __init__

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,12 @@ poetry install
 
 ```python
 import sqlite3
-from sqlite_store.arraystore.main import create_array_table, insert_array, insert_array_auto_hash, retrieve_array
+from sqlite_store.arraystore import (
+    create_array_table,
+    insert_array,
+    insert_array_auto_hash,
+    retrieve_array,
+)
 
 # SQLite接続
 conn = sqlite3.connect("example.db")
@@ -52,7 +57,11 @@ conn.close()
 
 ```python
 import sqlite3
-from sqlite_store.objectstore.main import create_object_table, insert_object, retrieve_object
+from sqlite_store.objectstore import (
+    create_object_table,
+    insert_object,
+    retrieve_object,
+)
 
 conn = sqlite3.connect("example.db")
 conn.row_factory = sqlite3.Row

--- a/sqlite_store/arraystore/__init__.py
+++ b/sqlite_store/arraystore/__init__.py
@@ -1,1 +1,17 @@
-# This file makes arraystore a Python package.
+"""Public API for the :mod:`sqlite_store.arraystore` package."""
+
+from .main import (
+    create_array_table,
+    insert_array,
+    insert_array_auto_hash,
+    insert_arrays_auto_hash,
+    retrieve_array,
+)
+
+__all__ = [
+    "create_array_table",
+    "insert_array",
+    "insert_array_auto_hash",
+    "insert_arrays_auto_hash",
+    "retrieve_array",
+]

--- a/sqlite_store/jsonstore/__init__.py
+++ b/sqlite_store/jsonstore/__init__.py
@@ -1,1 +1,15 @@
-# This file makes jsonstore a Python package.
+"""Public API for the :mod:`sqlite_store.jsonstore` package."""
+
+from .main import (
+    create_json_table,
+    insert_json,
+    insert_json_auto_hash,
+    retrieve_json,
+)
+
+__all__ = [
+    "create_json_table",
+    "insert_json",
+    "insert_json_auto_hash",
+    "retrieve_json",
+]

--- a/sqlite_store/objectstore/__init__.py
+++ b/sqlite_store/objectstore/__init__.py
@@ -1,1 +1,17 @@
-# This file makes objectstore a Python package.
+"""Public API for the :mod:`sqlite_store.objectstore` package."""
+
+from .main import (
+    create_object_table,
+    insert_object,
+    insert_object_auto_hash,
+    insert_objects_auto_hash,
+    retrieve_object,
+)
+
+__all__ = [
+    "create_object_table",
+    "insert_object",
+    "insert_object_auto_hash",
+    "insert_objects_auto_hash",
+    "retrieve_object",
+]


### PR DESCRIPTION
## Summary
- re-export public functions from each submodule via their `__init__`
- update README examples to import from package level instead of `.main`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4ec70668832bba4477f8646ea8f2