### PR TITLE
Add property concat view for objectstore

### DIFF
--- a/sqlite_store/objectstore/__init__.py
+++ b/sqlite_store/objectstore/__init__.py
@@ -7,6 +7,7 @@ from .main import (
     insert_objects_auto_hash,
     retrieve_object,
 )
+from .view import create_property_concat_view
 
 __all__ = [
     "create_object_table",
@@ -14,4 +15,5 @@ __all__ = [
     "insert_object_auto_hash",
     "insert_objects_auto_hash",
     "retrieve_object",
+    "create_property_concat_view",
 ]

--- a/sqlite_store/objectstore/view.py
+++ b/sqlite_store/objectstore/view.py
@@ -1,0 +1,24 @@
+import sqlite3
+
+
+def create_property_concat_view(
+    conn: sqlite3.Connection,
+    view_name: str = "objectstore_property_concat",
+    table_name: str = "objectstore",
+) -> None:
+    """Create a view that concatenates property_json values by object hash.
+
+    The view will contain ``canonical_json_sha1`` and a space separated
+    concatenation of ``property_json`` values for each hash.
+    """
+    conn.execute(
+        f"""
+        CREATE VIEW IF NOT EXISTS {view_name} AS
+        SELECT
+            canonical_json_sha1,
+            GROUP_CONCAT(property_json, ' ') AS property_json_space_joined
+        FROM {table_name}
+        GROUP BY canonical_json_sha1;
+        """
+    )
+    conn.commit()

--- a/tests/test_objectstore_view.py
+++ b/tests/test_objectstore_view.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import sqlite3
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from sqlite_store.objectstore.main import (
+    create_object_table,
+    insert_object,
+)
+from sqlite_store.objectstore.view import create_property_concat_view
+
+
+def test_property_concat_view_default():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    create_object_table(conn)
+    insert_object(conn, "hash1", {"a": 1, "b": True})
+    create_property_concat_view(conn)
+
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT property_json_space_joined FROM objectstore_property_concat WHERE canonical_json_sha1 = ?",
+        ("hash1",),
+    )
+    row = cur.fetchone()
+    assert row[0] == "1 true"
+    conn.close()
+
+
+def test_property_concat_view_custom_names():
+    table = "custom_objs"
+    view = "custom_view"
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    create_object_table(conn, table_name=table)
+    insert_object(conn, "h1", {"x": None, "y": 2}, table_name=table)
+    create_property_concat_view(conn, view_name=view, table_name=table)
+
+    cur = conn.cursor()
+    cur.execute(
+        f"SELECT property_json_space_joined FROM {view} WHERE canonical_json_sha1 = ?",
+        ("h1",),
+    )
+    row = cur.fetchone()
+    assert row[0] == "null 2"
+    conn.close()
+


### PR DESCRIPTION
## Summary
- add `create_property_concat_view` for building a view that concatenates objectstore properties
- export function via `objectstore.__init__`
- test default and custom view/table names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4d80ce08832b9c18f6c91973f236