### PR TITLE
Add jsonstore FTS support

### DIFF
--- a/sqlite_store/arraystore/__init__.py
+++ b/sqlite_store/arraystore/__init__.py
@@ -8,6 +8,7 @@ from .main import (
     retrieve_array,
 )
 from .view import create_element_concat_view
+from .fts import create_element_concat_fts
 
 __all__ = [
     "create_array_table",
@@ -16,4 +17,5 @@ __all__ = [
     "insert_arrays_auto_hash",
     "retrieve_array",
     "create_element_concat_view",
+    "create_element_concat_fts",
 ]

--- a/sqlite_store/arraystore/fts.py
+++ b/sqlite_store/arraystore/fts.py
@@ -1,0 +1,24 @@
+import sqlite3
+
+
+def create_element_concat_fts(
+    conn: sqlite3.Connection,
+    fts_table_name: str = "arraystore_element_fts",
+    view_name: str = "arraystore_element_concat",
+) -> None:
+    """Create FTS5 virtual table for the element concat view.
+
+    This creates an FTS5 table that allows full-text search over the
+    space-joined JSON element strings produced by
+    :func:`sqlite_store.arraystore.view.create_element_concat_view`.
+    """
+
+    conn.execute(
+        f"CREATE VIRTUAL TABLE IF NOT EXISTS {fts_table_name} "
+        "USING fts5(element_json_space_joined, canonical_json_sha1 UNINDEXED)"
+    )
+    conn.execute(
+        f"INSERT INTO {fts_table_name}(element_json_space_joined, canonical_json_sha1) "
+        f"SELECT element_json_space_joined, canonical_json_sha1 FROM {view_name}"
+    )
+    conn.commit()

--- a/sqlite_store/jsonstore/__init__.py
+++ b/sqlite_store/jsonstore/__init__.py
@@ -6,10 +6,12 @@ from .main import (
     insert_json_auto_hash,
     retrieve_json,
 )
+from .fts import create_json_fts
 
 __all__ = [
     "create_json_table",
     "insert_json",
     "insert_json_auto_hash",
     "retrieve_json",
+    "create_json_fts",
 ]

--- a/sqlite_store/jsonstore/fts.py
+++ b/sqlite_store/jsonstore/fts.py
@@ -1,0 +1,24 @@
+import sqlite3
+
+
+def create_json_fts(
+    conn: sqlite3.Connection,
+    fts_table_name: str = "jsonstore_fts",
+    table_name: str = "jsonstore",
+) -> None:
+    """Create FTS5 virtual table for the JSON store table.
+
+    This function creates an FTS5 table that indexes the ``canonical_json``
+    column from the table produced by
+    :func:`sqlite_store.jsonstore.main.create_json_table`.
+    """
+
+    conn.execute(
+        f"CREATE VIRTUAL TABLE IF NOT EXISTS {fts_table_name} "
+        "USING fts5(canonical_json, canonical_json_sha1 UNINDEXED)"
+    )
+    conn.execute(
+        f"INSERT INTO {fts_table_name}(canonical_json, canonical_json_sha1) "
+        f"SELECT canonical_json, canonical_json_sha1 FROM {table_name}"
+    )
+    conn.commit()

--- a/sqlite_store/objectstore/__init__.py
+++ b/sqlite_store/objectstore/__init__.py
@@ -8,6 +8,7 @@ from .main import (
     retrieve_object,
 )
 from .view import create_property_concat_view
+from .fts import create_property_concat_fts
 
 __all__ = [
     "create_object_table",
@@ -16,4 +17,5 @@ __all__ = [
     "insert_objects_auto_hash",
     "retrieve_object",
     "create_property_concat_view",
+    "create_property_concat_fts",
 ]

--- a/sqlite_store/objectstore/fts.py
+++ b/sqlite_store/objectstore/fts.py
@@ -1,0 +1,24 @@
+import sqlite3
+
+
+def create_property_concat_fts(
+    conn: sqlite3.Connection,
+    fts_table_name: str = "objectstore_property_fts",
+    view_name: str = "objectstore_property_concat",
+) -> None:
+    """Create FTS5 virtual table for the property concat view.
+
+    This function creates an FTS5 table that indexes the space-joined
+    JSON property strings produced by
+    :func:`sqlite_store.objectstore.view.create_property_concat_view`.
+    """
+
+    conn.execute(
+        f"CREATE VIRTUAL TABLE IF NOT EXISTS {fts_table_name} "
+        "USING fts5(property_json_space_joined, canonical_json_sha1 UNINDEXED)"
+    )
+    conn.execute(
+        f"INSERT INTO {fts_table_name}(property_json_space_joined, canonical_json_sha1) "
+        f"SELECT property_json_space_joined, canonical_json_sha1 FROM {view_name}"
+    )
+    conn.commit()

--- a/tests/test_arraystore_fts.py
+++ b/tests/test_arraystore_fts.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import sqlite3
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from sqlite_store.arraystore.main import create_array_table, insert_array
+from sqlite_store.arraystore.view import create_element_concat_view
+from sqlite_store.arraystore.fts import create_element_concat_fts
+
+
+def test_element_concat_fts_search():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    create_array_table(conn)
+    insert_array(conn, "h1", ["hello", "world"])
+    insert_array(conn, "h2", ["another", "test"])
+    create_element_concat_view(conn)
+    create_element_concat_fts(conn)
+
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT canonical_json_sha1 FROM arraystore_element_fts WHERE arraystore_element_fts MATCH ?",
+        ("hello",),
+    )
+    row = cur.fetchone()
+    assert row[0] == "h1"
+    conn.close()
+
+
+def test_element_concat_fts_custom_names():
+    table = "arrs"
+    view = "arrs_view"
+    fts = "arrs_fts"
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    create_array_table(conn, table_name=table)
+    insert_array(conn, "c1", ["alpha", "beta"], table_name=table)
+    create_element_concat_view(conn, view_name=view, table_name=table)
+    create_element_concat_fts(conn, fts_table_name=fts, view_name=view)
+
+    cur = conn.cursor()
+    cur.execute(
+        f"SELECT canonical_json_sha1 FROM {fts} WHERE {fts} MATCH ?",
+        ("alpha",),
+    )
+    row = cur.fetchone()
+    assert row[0] == "c1"
+    conn.close()

--- a/tests/test_jsonstore_fts.py
+++ b/tests/test_jsonstore_fts.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import sqlite3
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from sqlite_store.jsonstore.main import create_json_table, insert_json
+from sqlite_store.jsonstore.fts import create_json_fts
+
+
+def test_json_fts_search():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    create_json_table(conn)
+    insert_json(conn, "j1", {"text": "hello"})
+    insert_json(conn, "j2", {"text": "world"})
+    create_json_fts(conn)
+
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT canonical_json_sha1 FROM jsonstore_fts WHERE jsonstore_fts MATCH ?",
+        ("hello",),
+    )
+    row = cur.fetchone()
+    assert row[0] == "j1"
+    conn.close()
+
+
+def test_json_fts_custom_names():
+    table = "js"
+    fts = "js_fts"
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    create_json_table(conn, table_name=table)
+    insert_json(conn, "c1", {"msg": "alpha"}, table_name=table)
+    create_json_fts(conn, fts_table_name=fts, table_name=table)
+
+    cur = conn.cursor()
+    cur.execute(
+        f"SELECT canonical_json_sha1 FROM {fts} WHERE {fts} MATCH ?",
+        ("alpha",),
+    )
+    row = cur.fetchone()
+    assert row[0] == "c1"
+    conn.close()

--- a/tests/test_objectstore_fts.py
+++ b/tests/test_objectstore_fts.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import sqlite3
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from sqlite_store.objectstore.main import create_object_table, insert_object
+from sqlite_store.objectstore.view import create_property_concat_view
+from sqlite_store.objectstore.fts import create_property_concat_fts
+
+
+def test_property_concat_fts_search():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    create_object_table(conn)
+    insert_object(conn, "obj1", {"a": 1, "b": "text"})
+    insert_object(conn, "obj2", {"c": True})
+    create_property_concat_view(conn)
+    create_property_concat_fts(conn)
+
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT canonical_json_sha1 FROM objectstore_property_fts WHERE objectstore_property_fts MATCH ?",
+        ("text",),
+    )
+    row = cur.fetchone()
+    assert row[0] == "obj1"
+    conn.close()
+
+
+def test_property_concat_fts_custom_names():
+    table = "objs"
+    view = "objs_view"
+    fts = "objs_fts"
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    create_object_table(conn, table_name=table)
+    insert_object(conn, "h1", {"x": "hello"}, table_name=table)
+    create_property_concat_view(conn, view_name=view, table_name=table)
+    create_property_concat_fts(conn, fts_table_name=fts, view_name=view)
+
+    cur = conn.cursor()
+    cur.execute(
+        f"SELECT canonical_json_sha1 FROM {fts} WHERE {fts} MATCH ?",
+        ("hello",),
+    )
+    row = cur.fetchone()
+    assert row[0] == "h1"
+    conn.close()


### PR DESCRIPTION
## Summary
- implement `create_json_fts` in `jsonstore/fts.py`
- expose the helper through the `jsonstore` package API
- provide tests ensuring default and custom FTS table names work

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a53a374d8832bba1050b9db9b1fd1