### PR TITLE
Add ArrayStore convenience wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ print(restored)  # 元の配列と同じ型・値で復元されます
 conn.close()
 ```
 
+### ArrayStore クラス
+
+関数群の代わりに、テーブルやビューの作成を含めた便利なラッパークラス
+`ArrayStore` も利用できます。
+
+```python
+import sqlite3
+from sqlite_store.arraystore.store import ArrayStore
+
+conn = sqlite3.connect("example.db")
+conn.row_factory = sqlite3.Row
+
+store = ArrayStore(conn)
+cid = store.insert_array_auto_hash([1, 2, 3])
+restored = store.retrieve_array(cid)
+print(restored)
+
+conn.close()
+```
+
 ### objectstore モジュールによる辞書の保存
 
 `objectstore` は、辞書の各プロパティを JSON リテラルとして保存することで、

--- a/sqlite_store/arraystore/__init__.py
+++ b/sqlite_store/arraystore/__init__.py
@@ -9,6 +9,7 @@ from .table import (
 )
 from .view import create_element_concat_view
 from .fts import create_element_concat_fts
+from .store import ArrayStore
 
 __all__ = [
     "create_array_table",
@@ -18,4 +19,5 @@ __all__ = [
     "retrieve_array",
     "create_element_concat_view",
     "create_element_concat_fts",
+    "ArrayStore",
 ]

--- a/sqlite_store/arraystore/store.py
+++ b/sqlite_store/arraystore/store.py
@@ -1,0 +1,85 @@
+import sqlite3
+from typing import Any, List, Optional
+
+from .table import (
+    create_array_table,
+    insert_array,
+    insert_array_auto_hash,
+    insert_arrays_auto_hash,
+    retrieve_array,
+)
+from .view import create_element_concat_view
+from .fts import create_element_concat_fts
+
+
+class ArrayStore:
+    """Convenience wrapper class for array storage operations."""
+
+    def __init__(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        table_name: str = "arraystore",
+        view_name: Optional[str] = "arraystore_element_concat",
+        fts_table_name: Optional[str] = "arraystore_element_fts",
+    ) -> None:
+        self.conn = conn
+        self.table_name = table_name
+        self.view_name = view_name
+        self.fts_table_name = fts_table_name
+        create_array_table(conn, table_name=table_name)
+        if view_name is not None:
+            create_element_concat_view(conn, view_name=view_name, table_name=table_name)
+        if fts_table_name is not None:
+            if view_name is None:
+                create_element_concat_view(conn, table_name=table_name)
+                self.view_name = "arraystore_element_concat"
+            create_element_concat_fts(
+                conn,
+                fts_table_name=fts_table_name,
+                view_name=self.view_name,
+            )
+
+    def insert_array(self, canonical_json_sha1: str, array: List[Any]) -> None:
+        insert_array(
+            self.conn,
+            canonical_json_sha1,
+            array,
+            table_name=self.table_name,
+        )
+
+    def insert_array_auto_hash(self, array: List[Any]) -> str:
+        return insert_array_auto_hash(
+            self.conn,
+            array,
+            table_name=self.table_name,
+        )
+
+    def insert_arrays_auto_hash(self, arrays: List[List[Any]]) -> List[str]:
+        return insert_arrays_auto_hash(
+            self.conn,
+            arrays,
+            table_name=self.table_name,
+        )
+
+    def retrieve_array(self, canonical_json_sha1: str) -> List[Any]:
+        return retrieve_array(
+            self.conn,
+            canonical_json_sha1,
+            table_name=self.table_name,
+        )
+
+    def create_view(self) -> None:
+        create_element_concat_view(
+            self.conn,
+            view_name=self.view_name or "arraystore_element_concat",
+            table_name=self.table_name,
+        )
+
+    def create_fts(self) -> None:
+        create_element_concat_fts(
+            self.conn,
+            fts_table_name=self.fts_table_name or "arraystore_element_fts",
+            view_name=self.view_name or "arraystore_element_concat",
+        )
+

--- a/tests/test_arraystore_class.py
+++ b/tests/test_arraystore_class.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import sqlite3
+import hashlib
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from sqlite_store.arraystore.store import ArrayStore  # noqa: E402
+from sqlite_store import canonical_json  # noqa: E402
+
+
+def test_class_basic_storage():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    store = ArrayStore(conn)
+    arr = [1, True, None]
+    cid = "cid1"
+    store.insert_array(cid, arr)
+    result = store.retrieve_array(cid)
+
+    assert result == arr
+    conn.close()
+
+
+def test_class_auto_hash():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    store = ArrayStore(conn)
+    arr = ["a", {"b": False}]
+    cid = store.insert_array_auto_hash(arr)
+    result = store.retrieve_array(cid)
+    expected = hashlib.sha1(canonical_json(arr).encode("utf-8")).hexdigest()
+    assert cid == expected
+    assert result == arr
+    conn.close()
+
+
+def test_class_insert_arrays_auto_hash():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    store = ArrayStore(conn)
+    arrays = [[1], [True, False]]
+    hashes = store.insert_arrays_auto_hash(arrays)
+    assert len(hashes) == len(arrays)
+    for arr, cid in zip(arrays, hashes):
+        restored = store.retrieve_array(cid)
+        assert restored == arr
+    conn.close()
+
+
+def test_class_custom_names():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    store = ArrayStore(
+        conn,
+        table_name="t",
+        view_name="v",
+        fts_table_name="f",
+    )
+    cid = store.insert_array_auto_hash(["x"])
+    cur = conn.cursor()
+    cur.execute("SELECT element_json_space_joined FROM v WHERE canonical_json_sha1 = ?", (cid,))
+    row = cur.fetchone()
+    assert row[0] == "\"x\""
+    conn.close()
+


### PR DESCRIPTION
## Summary
- add `ArrayStore` class for simple object-oriented API
- expose `ArrayStore` in package exports
- document basic `ArrayStore` usage
- add tests covering the new class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a5c172cdc832ba77000f7b022c861