### PR TITLE
Add ObjectStore wrapper class

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,25 @@ print(restored)  # 元の辞書と同じ型・値で復元されます
 conn.close()
 ```
 
+### ObjectStore クラス
+
+辞書操作をより簡潔に行うためのラッパークラス `ObjectStore` も提供しています。
+
+```python
+import sqlite3
+from sqlite_store.objectstore.store import ObjectStore
+
+conn = sqlite3.connect("example.db")
+conn.row_factory = sqlite3.Row
+
+store = ObjectStore(conn)
+oid = store.insert_object_auto_hash({"x": 1, "y": True})
+restored = store.retrieve_object(oid)
+print(restored)
+
+conn.close()
+```
+
 ### canonical_json 関数
 
 オブジェクトを JSON Canonicalization Scheme (JCS) に従って文字列化する

--- a/sqlite_store/objectstore/__init__.py
+++ b/sqlite_store/objectstore/__init__.py
@@ -9,6 +9,7 @@ from .table import (
 )
 from .view import create_property_concat_view
 from .fts import create_property_concat_fts
+from .store import ObjectStore
 
 __all__ = [
     "create_object_table",
@@ -18,4 +19,5 @@ __all__ = [
     "retrieve_object",
     "create_property_concat_view",
     "create_property_concat_fts",
+    "ObjectStore",
 ]

--- a/sqlite_store/objectstore/store.py
+++ b/sqlite_store/objectstore/store.py
@@ -1,0 +1,84 @@
+import sqlite3
+from typing import Any, Dict, List, Optional
+
+from .table import (
+    create_object_table,
+    insert_object,
+    insert_object_auto_hash,
+    insert_objects_auto_hash,
+    retrieve_object,
+)
+from .view import create_property_concat_view
+from .fts import create_property_concat_fts
+
+
+class ObjectStore:
+    """Convenience wrapper class for object storage operations."""
+
+    def __init__(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        table_name: str = "objectstore",
+        view_name: Optional[str] = "objectstore_property_concat",
+        fts_table_name: Optional[str] = "objectstore_property_fts",
+    ) -> None:
+        self.conn = conn
+        self.table_name = table_name
+        self.view_name = view_name
+        self.fts_table_name = fts_table_name
+        create_object_table(conn, table_name=table_name)
+        if view_name is not None:
+            create_property_concat_view(conn, view_name=view_name, table_name=table_name)
+        if fts_table_name is not None:
+            if view_name is None:
+                create_property_concat_view(conn, table_name=table_name)
+                self.view_name = "objectstore_property_concat"
+            create_property_concat_fts(
+                conn,
+                fts_table_name=fts_table_name,
+                view_name=self.view_name,
+            )
+
+    def insert_object(self, canonical_json_sha1: str, obj: Dict[str, Any]) -> None:
+        insert_object(
+            self.conn,
+            canonical_json_sha1,
+            obj,
+            table_name=self.table_name,
+        )
+
+    def insert_object_auto_hash(self, obj: Dict[str, Any]) -> str:
+        return insert_object_auto_hash(
+            self.conn,
+            obj,
+            table_name=self.table_name,
+        )
+
+    def insert_objects_auto_hash(self, objs: List[Dict[str, Any]]) -> List[str]:
+        return insert_objects_auto_hash(
+            self.conn,
+            objs,
+            table_name=self.table_name,
+        )
+
+    def retrieve_object(self, canonical_json_sha1: str) -> Dict[str, Any]:
+        return retrieve_object(
+            self.conn,
+            canonical_json_sha1,
+            table_name=self.table_name,
+        )
+
+    def create_view(self) -> None:
+        create_property_concat_view(
+            self.conn,
+            view_name=self.view_name or "objectstore_property_concat",
+            table_name=self.table_name,
+        )
+
+    def create_fts(self) -> None:
+        create_property_concat_fts(
+            self.conn,
+            fts_table_name=self.fts_table_name or "objectstore_property_fts",
+            view_name=self.view_name or "objectstore_property_concat",
+        )

--- a/tests/test_objectstore_class.py
+++ b/tests/test_objectstore_class.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import sqlite3
+import hashlib
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from sqlite_store.objectstore.store import ObjectStore  # noqa: E402
+from sqlite_store import canonical_json  # noqa: E402
+
+
+def test_class_basic_storage():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    store = ObjectStore(conn)
+    obj = {"a": 1, "b": True, "c": None}
+    cid = "oid1"
+    store.insert_object(cid, obj)
+    result = store.retrieve_object(cid)
+
+    assert result == obj
+    conn.close()
+
+
+def test_class_auto_hash():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    store = ObjectStore(conn)
+    obj = {"x": [1], "y": False}
+    cid = store.insert_object_auto_hash(obj)
+    result = store.retrieve_object(cid)
+    expected = hashlib.sha1(canonical_json(obj).encode("utf-8")).hexdigest()
+    assert cid == expected
+    assert result == obj
+    conn.close()
+
+
+def test_class_insert_objects_auto_hash():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    store = ObjectStore(conn)
+    objects = [{"a": 1}, {"b": True, "c": None}]
+    hashes = store.insert_objects_auto_hash(objects)
+    assert len(hashes) == len(objects)
+    for obj, cid in zip(objects, hashes):
+        restored = store.retrieve_object(cid)
+        assert restored == obj
+    conn.close()
+
+
+def test_class_custom_names():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    store = ObjectStore(
+        conn,
+        table_name="t_obj",
+        view_name="v_obj",
+        fts_table_name="f_obj",
+    )
+    cid = store.insert_object_auto_hash({"x": "y"})
+    cur = conn.cursor()
+    cur.execute("SELECT property_json_space_joined FROM v_obj WHERE canonical_json_sha1 = ?", (cid,))
+    row = cur.fetchone()
+    assert row[0] == "\"y\""
+    conn.close()


### PR DESCRIPTION
## Summary
- implement `ObjectStore` class mirroring `ArrayStore`
- expose `ObjectStore` in `objectstore` package
- document usage of the new class in README
- test `ObjectStore` functionality

## Testing
- `pip install jcs pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a5dc15fc0832baa06392d35422151