### PR TITLE
Add JsonStore wrapper class

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,25 @@ print(restored)
 conn.close()
 ```
 
+### JsonStore クラス
+
+任意の配列や辞書を丸ごと保存できるラッパークラス `JsonStore` も利用できます。
+
+```python
+import sqlite3
+from sqlite_store.jsonstore.store import JsonStore
+
+conn = sqlite3.connect("example.db")
+conn.row_factory = sqlite3.Row
+
+store = JsonStore(conn)
+jid = store.insert_json_auto_hash({"msg": "hello"})
+restored = store.retrieve_json(jid)
+print(restored)
+
+conn.close()
+```
+
 ### canonical_json 関数
 
 オブジェクトを JSON Canonicalization Scheme (JCS) に従って文字列化する

--- a/sqlite_store/jsonstore/__init__.py
+++ b/sqlite_store/jsonstore/__init__.py
@@ -7,6 +7,7 @@ from .table import (
     retrieve_json,
 )
 from .fts import create_json_fts
+from .store import JsonStore
 
 __all__ = [
     "create_json_table",
@@ -14,4 +15,5 @@ __all__ = [
     "insert_json_auto_hash",
     "retrieve_json",
     "create_json_fts",
+    "JsonStore",
 ]

--- a/sqlite_store/jsonstore/store.py
+++ b/sqlite_store/jsonstore/store.py
@@ -1,0 +1,57 @@
+import sqlite3
+from typing import Any, Optional
+
+from .table import (
+    create_json_table,
+    insert_json,
+    insert_json_auto_hash,
+    retrieve_json,
+)
+from .fts import create_json_fts
+
+
+class JsonStore:
+    """Convenience wrapper class for JSON storage operations."""
+
+    def __init__(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        table_name: str = "jsonstore",
+        fts_table_name: Optional[str] = "jsonstore_fts",
+    ) -> None:
+        self.conn = conn
+        self.table_name = table_name
+        self.fts_table_name = fts_table_name
+        create_json_table(conn, table_name=table_name)
+        if fts_table_name is not None:
+            create_json_fts(conn, fts_table_name=fts_table_name, table_name=table_name)
+
+    def insert_json(self, canonical_json_sha1: str, obj: Any) -> None:
+        insert_json(
+            self.conn,
+            canonical_json_sha1,
+            obj,
+            table_name=self.table_name,
+        )
+
+    def insert_json_auto_hash(self, obj: Any) -> str:
+        return insert_json_auto_hash(
+            self.conn,
+            obj,
+            table_name=self.table_name,
+        )
+
+    def retrieve_json(self, canonical_json_sha1: str) -> Any:
+        return retrieve_json(
+            self.conn,
+            canonical_json_sha1,
+            table_name=self.table_name,
+        )
+
+    def create_fts(self) -> None:
+        create_json_fts(
+            self.conn,
+            fts_table_name=self.fts_table_name or "jsonstore_fts",
+            table_name=self.table_name,
+        )

--- a/tests/test_jsonstore_class.py
+++ b/tests/test_jsonstore_class.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import sqlite3
+import hashlib
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from sqlite_store.jsonstore.store import JsonStore  # noqa: E402
+from sqlite_store import canonical_json  # noqa: E402
+
+
+def test_class_basic_storage():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    store = JsonStore(conn)
+    data = {"a": [1, True], "b": None}
+    cid = "json1"
+    store.insert_json(cid, data)
+    result = store.retrieve_json(cid)
+
+    assert result == data
+    conn.close()
+
+
+def test_class_auto_hash():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    store = JsonStore(conn)
+    obj = {"x": 1, "y": False}
+    cid = store.insert_json_auto_hash(obj)
+    result = store.retrieve_json(cid)
+    expected = hashlib.sha1(canonical_json(obj).encode("utf-8")).hexdigest()
+    assert cid == expected
+    assert result == obj
+    conn.close()
+
+
+def test_class_custom_names():
+    table = "js_table"
+    fts = "js_fts"
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    store = JsonStore(conn, table_name=table, fts_table_name=fts)
+    cid = store.insert_json_auto_hash({"msg": "alpha"})
+    store.create_fts()
+    cur = conn.cursor()
+    cur.execute(
+        f"SELECT canonical_json_sha1 FROM {fts} WHERE {fts} MATCH ?",
+        ("alpha",),
+    )
+    row = cur.fetchone()
+    assert row[0] == cid
+    conn.close()


### PR DESCRIPTION
## Summary
- implement `JsonStore` wrapper similar to ArrayStore/ObjectStore
- expose class via `jsonstore.__init__`
- document JsonStore usage in README
- add tests for JsonStore wrapper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a5eefdd6c832ba61d33c3edc356e2