### PR TITLE
Remove defaults from module-level functions

### DIFF
--- a/sqlite_store/arraystore/fts.py
+++ b/sqlite_store/arraystore/fts.py
@@ -3,8 +3,8 @@ import sqlite3
 
 def create_element_concat_fts(
     conn: sqlite3.Connection,
-    fts_table_name: str = "arraystore_element_fts",
-    view_name: str = "arraystore_element_concat",
+    fts_table_name: str,
+    view_name: str,
 ) -> None:
     """Create FTS5 virtual table for the element concat view.
 

--- a/sqlite_store/arraystore/table.py
+++ b/sqlite_store/arraystore/table.py
@@ -20,15 +20,15 @@ def _canonical_json(obj: Any) -> str:
 
     return canonical_json(obj)
 
-def create_array_table(conn: sqlite3.Connection, table_name: str = "arraystore") -> None:
+def create_array_table(conn: sqlite3.Connection, table_name: str) -> None:
     """Create table and indexes to store array elements.
 
     Parameters
     ----------
     conn : sqlite3.Connection
         SQLite connection.
-    table_name : str, optional
-        Name of the table to create. Defaults to ``"arraystore"``.
+    table_name : str
+        Name of the table to create.
     """
 
     conn.execute(f"""
@@ -50,7 +50,7 @@ def insert_array(
     conn: sqlite3.Connection,
     canonical_json_sha1: str,
     array: List[Any],
-    table_name: str = "arraystore",
+    table_name: str,
 ) -> None:
     """Insert array into table using canonical JSON for each element."""
     cur = conn.cursor()
@@ -66,7 +66,7 @@ def insert_array(
 
 
 def insert_array_auto_hash(
-    conn: sqlite3.Connection, array: List[Any], table_name: str = "arraystore"
+    conn: sqlite3.Connection, array: List[Any], table_name: str
 ) -> str:
     """Insert array and compute canonical JSON SHA1 internally.
 
@@ -76,8 +76,8 @@ def insert_array_auto_hash(
         SQLite connection.
     array : list
         Array to store.
-    table_name : str, optional
-        Name of the table. Defaults to ``"arraystore"``.
+    table_name : str
+        Name of the table.
 
     Returns
     -------
@@ -92,7 +92,7 @@ def insert_array_auto_hash(
 
 
 def insert_arrays_auto_hash(
-    conn: sqlite3.Connection, arrays: List[List[Any]], table_name: str = "arraystore"
+    conn: sqlite3.Connection, arrays: List[List[Any]], table_name: str
 ) -> List[str]:
     """Insert multiple arrays at once computing SHA1 for each.
 
@@ -102,8 +102,8 @@ def insert_arrays_auto_hash(
         SQLite connection.
     arrays : list[list]
         List of arrays to store.
-    table_name : str, optional
-        Name of the table. Defaults to ``"arraystore"``.
+    table_name : str
+        Name of the table.
 
     Returns
     -------
@@ -131,7 +131,7 @@ def insert_arrays_auto_hash(
     return hashes
 
 def retrieve_array(
-    conn: sqlite3.Connection, canonical_json_sha1: str, table_name: str = "arraystore"
+    conn: sqlite3.Connection, canonical_json_sha1: str, table_name: str
 ) -> List[Any]:
     """Retrieve array as Python list with preserved types."""
     cur = conn.cursor()

--- a/sqlite_store/arraystore/view.py
+++ b/sqlite_store/arraystore/view.py
@@ -3,8 +3,8 @@ import sqlite3
 
 def create_element_concat_view(
     conn: sqlite3.Connection,
-    view_name: str = "arraystore_element_concat",
-    table_name: str = "arraystore",
+    view_name: str,
+    table_name: str,
 ) -> None:
     """Create a view that concatenates element_json values by array hash.
 

--- a/sqlite_store/jsonstore/fts.py
+++ b/sqlite_store/jsonstore/fts.py
@@ -3,8 +3,8 @@ import sqlite3
 
 def create_json_fts(
     conn: sqlite3.Connection,
-    fts_table_name: str = "jsonstore_fts",
-    table_name: str = "jsonstore",
+    fts_table_name: str,
+    table_name: str,
 ) -> None:
     """Create FTS5 virtual table for the JSON store table.
 

--- a/sqlite_store/jsonstore/table.py
+++ b/sqlite_store/jsonstore/table.py
@@ -9,15 +9,15 @@ def _canonical_json(obj) -> str:
     return canonical_json(obj)
 
 
-def create_json_table(conn: sqlite3.Connection, table_name: str = "jsonstore"):
+def create_json_table(conn: sqlite3.Connection, table_name: str):
     """Create a table for storing complete JSON structures.
 
     Parameters
     ----------
     conn : sqlite3.Connection
         SQLite connection.
-    table_name : str, optional
-        Name of the table to create. Defaults to ``"jsonstore"``.
+    table_name : str
+        Name of the table to create.
     """
     conn.execute(
         f"""
@@ -34,7 +34,7 @@ def insert_json(
     conn: sqlite3.Connection,
     canonical_json_sha1: str,
     obj,
-    table_name: str = "jsonstore",
+    table_name: str,
 ):
     """Insert JSON structure using the provided SHA1 hash."""
     value = canonical_json(obj)
@@ -45,7 +45,7 @@ def insert_json(
     conn.commit()
 
 
-def insert_json_auto_hash(conn: sqlite3.Connection, obj, table_name: str = "jsonstore") -> str:
+def insert_json_auto_hash(conn: sqlite3.Connection, obj, table_name: str) -> str:
     """Insert JSON structure computing its canonical SHA1 hash.
 
     Returns the computed SHA1 hash string.
@@ -56,7 +56,7 @@ def insert_json_auto_hash(conn: sqlite3.Connection, obj, table_name: str = "json
     return canon_sha1
 
 
-def retrieve_json(conn: sqlite3.Connection, canonical_json_sha1: str, table_name: str = "jsonstore"):
+def retrieve_json(conn: sqlite3.Connection, canonical_json_sha1: str, table_name: str):
     """Retrieve JSON structure previously stored."""
     cur = conn.cursor()
     cur.execute(

--- a/sqlite_store/objectstore/fts.py
+++ b/sqlite_store/objectstore/fts.py
@@ -3,8 +3,8 @@ import sqlite3
 
 def create_property_concat_fts(
     conn: sqlite3.Connection,
-    fts_table_name: str = "objectstore_property_fts",
-    view_name: str = "objectstore_property_concat",
+    fts_table_name: str,
+    view_name: str,
 ) -> None:
     """Create FTS5 virtual table for the property concat view.
 

--- a/sqlite_store/objectstore/table.py
+++ b/sqlite_store/objectstore/table.py
@@ -20,15 +20,15 @@ def _canonical_json(obj: Any) -> str:
     return canonical_json(obj)
 
 
-def create_object_table(conn: sqlite3.Connection, table_name: str = "objectstore") -> None:
+def create_object_table(conn: sqlite3.Connection, table_name: str) -> None:
     """Create table and indexes to store object properties.
 
     Parameters
     ----------
     conn : sqlite3.Connection
         SQLite connection.
-    table_name : str, optional
-        Name of the table to create. Defaults to ``"objectstore"``.
+    table_name : str
+        Name of the table to create.
     """
     conn.execute(
         f"""
@@ -51,7 +51,7 @@ def insert_object(
     conn: sqlite3.Connection,
     canonical_json_sha1: str,
     obj: Dict[str, Any],
-    table_name: str = "objectstore",
+    table_name: str,
 ) -> None:
     """Insert a Python dict into the table preserving JSON types."""
     cur = conn.cursor()
@@ -68,7 +68,7 @@ def insert_object(
 def insert_object_auto_hash(
     conn: sqlite3.Connection,
     obj: Dict[str, Any],
-    table_name: str = "objectstore",
+    table_name: str,
 ) -> str:
     """Insert object and compute canonical JSON SHA1 internally.
 
@@ -78,8 +78,8 @@ def insert_object_auto_hash(
         SQLite connection.
     obj : dict
         Object to store.
-    table_name : str, optional
-        Name of the table. Defaults to ``"objectstore"``.
+    table_name : str
+        Name of the table.
 
     Returns
     -------
@@ -96,7 +96,7 @@ def insert_object_auto_hash(
 def insert_objects_auto_hash(
     conn: sqlite3.Connection,
     objs: List[Dict[str, Any]],
-    table_name: str = "objectstore",
+    table_name: str,
 ) -> List[str]:
     """Insert multiple objects computing canonical JSON SHA1 for each.
 
@@ -106,8 +106,8 @@ def insert_objects_auto_hash(
         SQLite connection.
     objs : list of dict
         Objects to store.
-    table_name : str, optional
-        Name of the table. Defaults to ``"objectstore"``.
+    table_name : str
+        Name of the table.
 
     Returns
     -------
@@ -134,7 +134,7 @@ def insert_objects_auto_hash(
 def retrieve_object(
     conn: sqlite3.Connection,
     canonical_json_sha1: str,
-    table_name: str = "objectstore",
+    table_name: str,
 ) -> Dict[str, Any]:
     """Retrieve a Python dict previously stored with insert_object."""
     cur = conn.cursor()

--- a/sqlite_store/objectstore/view.py
+++ b/sqlite_store/objectstore/view.py
@@ -3,8 +3,8 @@ import sqlite3
 
 def create_property_concat_view(
     conn: sqlite3.Connection,
-    view_name: str = "objectstore_property_concat",
-    table_name: str = "objectstore",
+    view_name: str,
+    table_name: str,
 ) -> None:
     """Create a view that concatenates property_json values by object hash.
 

--- a/tests/test_arraystore.py
+++ b/tests/test_arraystore.py
@@ -24,9 +24,9 @@ def test_method1_storage():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_array_table(conn)
-    insert_array(conn, canonical_json_sha1, test_array)
-    result = retrieve_array(conn, canonical_json_sha1)
+    create_array_table(conn, table_name="arraystore")
+    insert_array(conn, canonical_json_sha1, test_array, table_name="arraystore")
+    result = retrieve_array(conn, canonical_json_sha1, table_name="arraystore")
 
     assert result == test_array, (
         f"Restored array does not match original.\n"
@@ -48,9 +48,9 @@ def test_method1_nested_array():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_array_table(conn)
-    insert_array(conn, canonical_json_sha1, nested_array)
-    result = retrieve_array(conn, canonical_json_sha1)
+    create_array_table(conn, table_name="arraystore")
+    insert_array(conn, canonical_json_sha1, nested_array, table_name="arraystore")
+    result = retrieve_array(conn, canonical_json_sha1, table_name="arraystore")
 
     assert result == nested_array, (
         f"Restored nested array does not match original.\n"
@@ -75,9 +75,9 @@ def test_method1_object_array():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_array_table(conn)
-    insert_array(conn, canonical_json_sha1, object_array)
-    result = retrieve_array(conn, canonical_json_sha1)
+    create_array_table(conn, table_name="arraystore")
+    insert_array(conn, canonical_json_sha1, object_array, table_name="arraystore")
+    result = retrieve_array(conn, canonical_json_sha1, table_name="arraystore")
 
     assert result == object_array, (
         f"Restored object array does not match original.\n"
@@ -115,9 +115,9 @@ def test_insert_array_auto_hash():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_array_table(conn)
-    computed_hash = insert_array_auto_hash(conn, arr)
-    result = retrieve_array(conn, computed_hash)
+    create_array_table(conn, table_name="arraystore")
+    computed_hash = insert_array_auto_hash(conn, arr, table_name="arraystore")
+    result = retrieve_array(conn, computed_hash, table_name="arraystore")
 
     expected_hash = hashlib.sha1(canonical_json(arr).encode("utf-8")).hexdigest()
 
@@ -133,8 +133,8 @@ def test_element_json_canonical():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_array_table(conn)
-    insert_array(conn, cid, data)
+    create_array_table(conn, table_name="arraystore")
+    insert_array(conn, cid, data, table_name="arraystore")
 
     cur = conn.cursor()
     cur.execute(
@@ -157,12 +157,12 @@ def test_insert_arrays_auto_hash():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_array_table(conn)
-    hashes = insert_arrays_auto_hash(conn, arrays)
+    create_array_table(conn, table_name="arraystore")
+    hashes = insert_arrays_auto_hash(conn, arrays, table_name="arraystore")
 
     assert len(hashes) == len(arrays)
     for arr, cid in zip(arrays, hashes):
-        restored = retrieve_array(conn, cid)
+        restored = retrieve_array(conn, cid, table_name="arraystore")
         expected = hashlib.sha1(canonical_json(arr).encode("utf-8")).hexdigest()
         assert cid == expected
         assert restored == arr

--- a/tests/test_arraystore_fts.py
+++ b/tests/test_arraystore_fts.py
@@ -12,11 +12,19 @@ def test_element_concat_fts_search():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_array_table(conn)
-    insert_array(conn, "h1", ["hello", "world"])
-    insert_array(conn, "h2", ["another", "test"])
-    create_element_concat_view(conn)
-    create_element_concat_fts(conn)
+    create_array_table(conn, table_name="arraystore")
+    insert_array(conn, "h1", ["hello", "world"], table_name="arraystore")
+    insert_array(conn, "h2", ["another", "test"], table_name="arraystore")
+    create_element_concat_view(
+        conn,
+        view_name="arraystore_element_concat",
+        table_name="arraystore",
+    )
+    create_element_concat_fts(
+        conn,
+        fts_table_name="arraystore_element_fts",
+        view_name="arraystore_element_concat",
+    )
 
     cur = conn.cursor()
     cur.execute(

--- a/tests/test_arraystore_view.py
+++ b/tests/test_arraystore_view.py
@@ -11,9 +11,13 @@ def test_element_concat_view_default():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_array_table(conn)
-    insert_array(conn, "hash1", [1, True])
-    create_element_concat_view(conn)
+    create_array_table(conn, table_name="arraystore")
+    insert_array(conn, "hash1", [1, True], table_name="arraystore")
+    create_element_concat_view(
+        conn,
+        view_name="arraystore_element_concat",
+        table_name="arraystore",
+    )
 
     cur = conn.cursor()
     cur.execute(

--- a/tests/test_jsonstore.py
+++ b/tests/test_jsonstore.py
@@ -21,9 +21,9 @@ def test_json_storage():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_json_table(conn)
-    insert_json(conn, cid, data)
-    result = retrieve_json(conn, cid)
+    create_json_table(conn, table_name="jsonstore")
+    insert_json(conn, cid, data, table_name="jsonstore")
+    result = retrieve_json(conn, cid, table_name="jsonstore")
 
     assert result == data
     assert json.dumps(result, sort_keys=True) == json.dumps(data, sort_keys=True)
@@ -35,9 +35,9 @@ def test_insert_json_auto_hash():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_json_table(conn)
-    computed_hash = insert_json_auto_hash(conn, obj)
-    result = retrieve_json(conn, computed_hash)
+    create_json_table(conn, table_name="jsonstore")
+    computed_hash = insert_json_auto_hash(conn, obj, table_name="jsonstore")
+    result = retrieve_json(conn, computed_hash, table_name="jsonstore")
 
     expected_hash = hashlib.sha1(canonical_json(obj).encode("utf-8")).hexdigest()
 
@@ -52,8 +52,8 @@ def test_json_column_canonical():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_json_table(conn)
-    insert_json(conn, cid, obj)
+    create_json_table(conn, table_name="jsonstore")
+    insert_json(conn, cid, obj, table_name="jsonstore")
 
     cur = conn.cursor()
     cur.execute("SELECT canonical_json FROM jsonstore WHERE canonical_json_sha1 = ?", (cid,))
@@ -85,9 +85,9 @@ def test_jsonstore_various_types_and_strings():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_json_table(conn)
-    hash_id = insert_json_auto_hash(conn, complex_obj)
-    result = retrieve_json(conn, hash_id)
+    create_json_table(conn, table_name="jsonstore")
+    hash_id = insert_json_auto_hash(conn, complex_obj, table_name="jsonstore")
+    result = retrieve_json(conn, hash_id, table_name="jsonstore")
 
     assert result == complex_obj
     conn.close()
@@ -113,13 +113,13 @@ def test_large_random_unicode_strings():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_json_table(conn)
+    create_json_table(conn, table_name="jsonstore")
 
     strings = [_random_unicode_string(rng, 102400) for _ in range(100)]
-    hashes = [insert_json_auto_hash(conn, s) for s in strings]
+    hashes = [insert_json_auto_hash(conn, s, table_name="jsonstore") for s in strings]
 
     for cid, original in zip(hashes, strings):
-        restored = retrieve_json(conn, cid)
+        restored = retrieve_json(conn, cid, table_name="jsonstore")
         assert restored == original
 
     conn.close()

--- a/tests/test_jsonstore_fts.py
+++ b/tests/test_jsonstore_fts.py
@@ -11,10 +11,14 @@ def test_json_fts_search():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_json_table(conn)
-    insert_json(conn, "j1", {"text": "hello"})
-    insert_json(conn, "j2", {"text": "world"})
-    create_json_fts(conn)
+    create_json_table(conn, table_name="jsonstore")
+    insert_json(conn, "j1", {"text": "hello"}, table_name="jsonstore")
+    insert_json(conn, "j2", {"text": "world"}, table_name="jsonstore")
+    create_json_fts(
+        conn,
+        fts_table_name="jsonstore_fts",
+        table_name="jsonstore",
+    )
 
     cur = conn.cursor()
     cur.execute(

--- a/tests/test_objectstore.py
+++ b/tests/test_objectstore.py
@@ -21,9 +21,9 @@ def test_object_storage():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_object_table(conn)
-    insert_object(conn, canonical_json_sha1, data)
-    result = retrieve_object(conn, canonical_json_sha1)
+    create_object_table(conn, table_name="objectstore")
+    insert_object(conn, canonical_json_sha1, data, table_name="objectstore")
+    result = retrieve_object(conn, canonical_json_sha1, table_name="objectstore")
 
     assert result == data
     assert json.dumps(result, sort_keys=True) == json.dumps(data, sort_keys=True)
@@ -69,9 +69,9 @@ def test_object_storage_various_types():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_object_table(conn)
-    insert_object(conn, obj_hash, data)
-    result = retrieve_object(conn, obj_hash)
+    create_object_table(conn, table_name="objectstore")
+    insert_object(conn, obj_hash, data, table_name="objectstore")
+    result = retrieve_object(conn, obj_hash, table_name="objectstore")
 
     assert result == data
     for key, val in data.items():
@@ -85,9 +85,9 @@ def test_insert_object_auto_hash():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_object_table(conn)
-    computed_hash = insert_object_auto_hash(conn, obj)
-    result = retrieve_object(conn, computed_hash)
+    create_object_table(conn, table_name="objectstore")
+    computed_hash = insert_object_auto_hash(conn, obj, table_name="objectstore")
+    result = retrieve_object(conn, computed_hash, table_name="objectstore")
 
     expected_hash = hashlib.sha1(canonical_json(obj).encode("utf-8")).hexdigest()
 
@@ -107,8 +107,8 @@ def test_property_json_is_canonical():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_object_table(conn)
-    insert_object(conn, hash_id, obj)
+    create_object_table(conn, table_name="objectstore")
+    insert_object(conn, hash_id, obj, table_name="objectstore")
 
     cur = conn.cursor()
     cur.execute(
@@ -136,8 +136,8 @@ def test_insert_objects_auto_hash():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_object_table(conn)
-    hashes = insert_objects_auto_hash(conn, objs)
+    create_object_table(conn, table_name="objectstore")
+    hashes = insert_objects_auto_hash(conn, objs, table_name="objectstore")
 
     expected = [
         hashlib.sha1(canonical_json(o).encode("utf-8")).hexdigest() for o in objs
@@ -145,6 +145,6 @@ def test_insert_objects_auto_hash():
 
     assert hashes == expected
     for h, original in zip(hashes, objs):
-        restored = retrieve_object(conn, h)
+        restored = retrieve_object(conn, h, table_name="objectstore")
         assert restored == original
     conn.close()

--- a/tests/test_objectstore_fts.py
+++ b/tests/test_objectstore_fts.py
@@ -12,11 +12,19 @@ def test_property_concat_fts_search():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_object_table(conn)
-    insert_object(conn, "obj1", {"a": 1, "b": "text"})
-    insert_object(conn, "obj2", {"c": True})
-    create_property_concat_view(conn)
-    create_property_concat_fts(conn)
+    create_object_table(conn, table_name="objectstore")
+    insert_object(conn, "obj1", {"a": 1, "b": "text"}, table_name="objectstore")
+    insert_object(conn, "obj2", {"c": True}, table_name="objectstore")
+    create_property_concat_view(
+        conn,
+        view_name="objectstore_property_concat",
+        table_name="objectstore",
+    )
+    create_property_concat_fts(
+        conn,
+        fts_table_name="objectstore_property_fts",
+        view_name="objectstore_property_concat",
+    )
 
     cur = conn.cursor()
     cur.execute(

--- a/tests/test_objectstore_view.py
+++ b/tests/test_objectstore_view.py
@@ -14,9 +14,13 @@ def test_property_concat_view_default():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
 
-    create_object_table(conn)
-    insert_object(conn, "hash1", {"a": 1, "b": True})
-    create_property_concat_view(conn)
+    create_object_table(conn, table_name="objectstore")
+    insert_object(conn, "hash1", {"a": 1, "b": True}, table_name="objectstore")
+    create_property_concat_view(
+        conn,
+        view_name="objectstore_property_concat",
+        table_name="objectstore",
+    )
 
     cur = conn.cursor()
     cur.execute(


### PR DESCRIPTION
## Summary
- update table/view/fts functions to require explicit table and view names
- adjust tests to pass table/view names when calling functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a61248810832ba2f0d20ec770eea5