### PR TITLE
Implement bulk JSON retrieval

### DIFF
--- a/jsonstore/jsonstore/__init__.py
+++ b/jsonstore/jsonstore/__init__.py
@@ -5,6 +5,7 @@ from .table import (
     insert_json,
     insert_json_auto_hash,
     retrieve_json,
+    retrieve_all_json,
 )
 from .fts import create_json_fts
 from .store import JsonStore
@@ -14,6 +15,7 @@ __all__ = [
     "insert_json",
     "insert_json_auto_hash",
     "retrieve_json",
+    "retrieve_all_json",
     "create_json_fts",
     "JsonStore",
 ]

--- a/jsonstore/jsonstore/store.py
+++ b/jsonstore/jsonstore/store.py
@@ -6,6 +6,7 @@ from .table import (
     insert_json,
     insert_json_auto_hash,
     retrieve_json,
+    retrieve_all_json,
 )
 from .fts import create_json_fts
 
@@ -46,6 +47,12 @@ class JsonStore:
         return retrieve_json(
             self.conn,
             canonical_json_sha1,
+            table_name=self.table_name,
+        )
+
+    def retrieve_all_json(self) -> list:
+        return retrieve_all_json(
+            self.conn,
             table_name=self.table_name,
         )
 

--- a/jsonstore/jsonstore/table.py
+++ b/jsonstore/jsonstore/table.py
@@ -68,3 +68,12 @@ def retrieve_json(conn: sqlite3.Connection, canonical_json_sha1: str, table_name
 
     return json.loads(row[0]) if row else None
 
+
+def retrieve_all_json(conn: sqlite3.Connection, table_name: str):
+    """Return all JSON records stored in ``table_name`` as a list."""
+    cur = conn.cursor()
+    cur.execute(f"SELECT canonical_json FROM {table_name}")
+    rows = cur.fetchall()
+    import json
+    return [json.loads(r[0]) for r in rows]
+

--- a/tests/test_jsonstore.py
+++ b/tests/test_jsonstore.py
@@ -11,6 +11,7 @@ from jsonstore.jsonstore.table import (
     insert_json,
     insert_json_auto_hash,
     retrieve_json,
+    retrieve_all_json,
 )
 from jsonstore import canonical_json
 
@@ -122,4 +123,20 @@ def test_large_random_unicode_strings():
         restored = retrieve_json(conn, cid, table_name="jsonstore")
         assert restored == original
 
+    conn.close()
+
+
+def test_retrieve_all_json():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    create_json_table(conn, table_name="jsonstore")
+    data = [{"id": i} for i in range(3)]
+    for obj in data:
+        insert_json_auto_hash(conn, obj, table_name="jsonstore")
+
+    records = retrieve_all_json(conn, table_name="jsonstore")
+    records_sorted = sorted(records, key=lambda x: x["id"])
+
+    assert records_sorted == data
     conn.close()

--- a/tests/test_jsonstore_class.py
+++ b/tests/test_jsonstore_class.py
@@ -51,3 +51,19 @@ def test_class_custom_names():
     row = cur.fetchone()
     assert row[0] == cid
     conn.close()
+
+
+def test_class_retrieve_all_json():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    store = JsonStore(conn)
+
+    data = [{"v": i} for i in range(5)]
+    for obj in data:
+        store.insert_json_auto_hash(obj)
+
+    records = store.retrieve_all_json()
+    records_sorted = sorted(records, key=lambda x: x["v"])
+
+    assert records_sorted == data
+    conn.close()


### PR DESCRIPTION
## Summary
- support retrieving all records from the JSON table
- expose new API in `__init__` and `JsonStore`
- test retrieving all records via function and class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b89aa05b8832bbb96803f126dff9b