### PR TITLE
Add function to retrieve all arrays

### DIFF
--- a/jsonstore/arraystore/__init__.py
+++ b/jsonstore/arraystore/__init__.py
@@ -6,6 +6,7 @@ from .table import (
     insert_array_auto_hash,
     insert_arrays_auto_hash,
     retrieve_array,
+    retrieve_all_arrays,
 )
 from .view import create_element_concat_view
 from .fts import create_element_concat_fts
@@ -17,6 +18,7 @@ __all__ = [
     "insert_array_auto_hash",
     "insert_arrays_auto_hash",
     "retrieve_array",
+    "retrieve_all_arrays",
     "create_element_concat_view",
     "create_element_concat_fts",
     "ArrayStore",

--- a/jsonstore/arraystore/store.py
+++ b/jsonstore/arraystore/store.py
@@ -7,6 +7,7 @@ from .table import (
     insert_array_auto_hash,
     insert_arrays_auto_hash,
     retrieve_array,
+    retrieve_all_arrays,
 )
 from .view import create_element_concat_view
 from .fts import create_element_concat_fts
@@ -66,6 +67,13 @@ class ArrayStore:
         return retrieve_array(
             self.conn,
             canonical_json_sha1,
+            table_name=self.table_name,
+        )
+
+    def retrieve_all_arrays(self) -> List[List[Any]]:
+        """Return all arrays stored in this :class:`ArrayStore`."""
+        return retrieve_all_arrays(
+            self.conn,
             table_name=self.table_name,
         )
 

--- a/jsonstore/arraystore/table.py
+++ b/jsonstore/arraystore/table.py
@@ -146,3 +146,17 @@ def retrieve_array(
     )
     row = cur.fetchone()
     return json.loads(row['json_array']) if row else []
+
+
+def retrieve_all_arrays(conn: sqlite3.Connection, table_name: str) -> List[List[Any]]:
+    """Return all arrays stored in ``table_name`` as a list of lists."""
+    cur = conn.cursor()
+    cur.execute(
+        f"""
+        SELECT '[' || GROUP_CONCAT(element_json, ',') || ']' AS json_array
+        FROM {table_name}
+        GROUP BY canonical_json_sha1;
+    """
+    )
+    rows = cur.fetchall()
+    return [json.loads(row['json_array']) for row in rows]

--- a/tests/test_arraystore.py
+++ b/tests/test_arraystore.py
@@ -12,6 +12,7 @@ from jsonstore.arraystore.table import (
     insert_array_auto_hash,
     insert_arrays_auto_hash,
     retrieve_array,
+    retrieve_all_arrays,
 )
 from jsonstore import canonical_json
 import hashlib
@@ -166,6 +167,22 @@ def test_insert_arrays_auto_hash():
         expected = hashlib.sha1(canonical_json(arr).encode("utf-8")).hexdigest()
         assert cid == expected
         assert restored == arr
+    conn.close()
+
+
+def test_retrieve_all_arrays():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    create_array_table(conn, table_name="arraystore")
+    arrays = [[i] for i in range(3)]
+    for arr in arrays:
+        insert_array_auto_hash(conn, arr, table_name="arraystore")
+
+    records = retrieve_all_arrays(conn, table_name="arraystore")
+    records_sorted = sorted(records, key=lambda x: x[0])
+
+    assert records_sorted == arrays
     conn.close()
 
 

--- a/tests/test_arraystore_class.py
+++ b/tests/test_arraystore_class.py
@@ -64,3 +64,19 @@ def test_class_custom_names():
     assert row[0] == "\"x\""
     conn.close()
 
+
+def test_class_retrieve_all_arrays():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    store = ArrayStore(conn)
+
+    arrays = [[i] for i in range(4)]
+    for arr in arrays:
+        store.insert_array_auto_hash(arr)
+
+    records = store.retrieve_all_arrays()
+    records_sorted = sorted(records, key=lambda x: x[0])
+
+    assert records_sorted == arrays
+    conn.close()
+


### PR DESCRIPTION
## Summary
- allow loading all arrays from arraystore tables
- expose retrieve_all_arrays in public API and `ArrayStore`
- test retrieving all arrays via functions and class method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bc623dd84832baf22afb484415ef6