### PR TITLE
Add httpimport remote import test

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,29 @@ pip install .
 poetry install
 ```
 
+### httpimport を利用したリモートインポート
+
+`httpimport` を使うと、GitHub 上のリポジトリから直接このパッケージを
+インポートして利用することもできます。以下は基本的な例です。
+
+```python
+from httpimport import github_repo
+
+with github_repo('TakashiSasaki', 'jsonstore', ref='master'):
+    from jsonstore import canonical_json
+    from jsonstore.jsonstore.store import JsonStore
+    import sqlite3
+
+    data = {'b': 1, 'a': [True, None]}
+    print('canonical_json:', canonical_json(data))
+    conn = sqlite3.connect(':memory:')
+    conn.row_factory = sqlite3.Row
+    store = JsonStore(conn)
+    sha1 = store.insert_json_auto_hash(data)
+    retrieved = store.retrieve_json(sha1)
+    print('retrieved:', retrieved)
+```
+
 ## 使い方
 
 ```python

--- a/tests/test_httpimport.py
+++ b/tests/test_httpimport.py
@@ -1,0 +1,33 @@
+import subprocess
+import sys
+import textwrap
+import pytest
+
+pytest.importorskip("httpimport")
+
+
+def test_remote_import_via_httpimport():
+    script = textwrap.dedent(
+        """
+        from httpimport import github_repo
+        import sqlite3
+        import jcs
+        with github_repo('TakashiSasaki', 'jsonstore', ref='master'):
+            from jsonstore import canonical_json
+            from jsonstore.jsonstore.store import JsonStore
+            data = {'b': 1, 'a': [True, None]}
+            result = canonical_json(data)
+            assert result == jcs.canonicalize(data).decode('utf-8')
+            conn = sqlite3.connect(':memory:')
+            conn.row_factory = sqlite3.Row
+            store = JsonStore(conn)
+            sha1 = store.insert_json_auto_hash(data)
+            restored = store.retrieve_json(sha1)
+            assert restored == data
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+


### PR DESCRIPTION
## Summary
- add a regression test under `tests/` verifying that the package can be imported from GitHub via `httpimport`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c9465dfc4832b85bf1a0087440fbf